### PR TITLE
feat(default/typescript templates): add .env and upgrade react dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ dist
 
 # misc
 .DS_Store
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/template/default/.gitignore
+++ b/template/default/.gitignore
@@ -9,7 +9,6 @@ dist
 
 # misc
 .DS_Store
-.env
 .env.local
 .env.development.local
 .env.test.local

--- a/template/default/example/.env
+++ b/template/default/example/.env
@@ -1,0 +1,4 @@
+# Added to prevent error with mismatching eslint versions
+# between the package and the /example due to the way npm/yarn link work.
+# See issue for more info: https://github.com/Hermanya/create-react-hook/issues/3
+SKIP_PREFLIGHT_CHECK=true

--- a/template/default/example/package.json
+++ b/template/default/example/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "prop-types": "^15.6.2",
     "react": "{{#if yarn}}link:../node_modules/react{{else}}file:../node_modules/react{{/if}}",
-    "react-dom": "^16.8.0-alpha.1",
-    "react-scripts": "^2.1.3",
+    "react-dom": "^16.8.6",
+    "react-scripts": "^3.0.0",
     "{{name}}": "{{#if yarn}}link:..{{else}}file:..{{/if}}"
   },
   "scripts": {

--- a/template/default/package.json
+++ b/template/default/package.json
@@ -45,7 +45,7 @@
     "@babel/plugin-syntax-import-meta": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "babel-eslint": "^9.0.0",
+    "babel-eslint": "^10.0.0",
     "cross-env": "^5.2.0",
     "eslint": "5.6.0",
     "eslint-config-standard": "^11.0.0",

--- a/template/default/package.json
+++ b/template/default/package.json
@@ -22,7 +22,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.8.0-alpha.1"
+    "react": "^16.8.6"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -56,8 +56,8 @@
     "eslint-plugin-react": "^7.10.0",
     "eslint-plugin-standard": "^3.1.0",
     "gh-pages": "^2.0.1",
-    "react": "^16.8.0-alpha.1",
-    "react-scripts": "^2.1.3",
+    "react": "^16.8.6",
+    "react-scripts": "^3.0.0",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.0",

--- a/template/typescript/example/package.json
+++ b/template/typescript/example/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "react": "{{#if yarn}}link:../node_modules/react{{else}}file:../node_modules/react{{/if}}",
-    "react-dom": "^16.8.8",
+    "react-dom": "^16.8.6",
     "react-scripts": "^3.0.0",
     "{{name}}": "{{#if yarn}}link:..{{else}}file:..{{/if}}"
   },

--- a/template/typescript/example/package.json
+++ b/template/typescript/example/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "dependencies": {
     "react": "{{#if yarn}}link:../node_modules/react{{else}}file:../node_modules/react{{/if}}",
-    "react-dom": "^16.8.0-alpha.1",
-    "react-scripts": "^2.1.3",
+    "react-dom": "^16.8.8",
+    "react-scripts": "^3.0.0",
     "{{name}}": "{{#if yarn}}link:..{{else}}file:..{{/if}}"
   },
   "scripts": {

--- a/template/typescript/package.json
+++ b/template/typescript/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "^16.8.0-alpha.1"
+    "react": "^16.8.6"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -32,8 +32,8 @@
     "@types/react": "^16.7.22",
     "cross-env": "^5.2.0",
     "gh-pages": "^2.0.1",
-    "react": "^16.8.0-alpha.1",
-    "react-scripts": "^2.1.3",
+    "react": "^16.8.6",
+    "react-scripts": "^3.0.0",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.0",


### PR DESCRIPTION
This PR fixes #3 by adding a `.env` to the `default` template. In addition, it upgrades `react` and `react-dom` to [`v16.8.6`](https://github.com/facebook/react/blob/master/CHANGELOG.md#1686-march-27-2019) and `react-scripts` to [`v3.0.0`](https://github.com/facebook/create-react-app/blob/master/CHANGELOG.md#300-april-22-2019).

### Screenshots and Screenrecordings

Example testing the default template after the changes using `npm`
![test-env-default](https://user-images.githubusercontent.com/3806031/61583562-bceb8200-aaee-11e9-81d3-4c8f51121bb1.gif)

### Testing
- [X] verified `/example` default starter with `npm` works 
- [X] verified `/example` default starter with `yarn` works 
- [X] verified `/example` typescript starter with `npm` works 
- [X] verified `/example` typescript starter with `yarn` works 

