### PR TITLE
Updating react scripts to 3.4.0 - `test` fixed by maintainers

### DIFF
--- a/template/default/package.json
+++ b/template/default/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-standard": "^3.1.0",
     "gh-pages": "^2.0.1",
     "react": "^16.9.0",
-    "react-scripts": "^3.0.1",
+    "react-scripts": "^3.4.0",
     "react-test-renderer": "^16.9.0",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",

--- a/template/typescript/package.json
+++ b/template/typescript/package.json
@@ -34,7 +34,7 @@
     "cross-env": "^5.2.0",
     "gh-pages": "^2.0.1",
     "react": "^16.9.0",
-    "react-scripts": "^3.0.1",
+    "react-scripts": "^3.4.0",
     "react-test-renderer": "^16.9.0",
     "rollup": "^1.1.2",
     "rollup-plugin-babel": "^4.3.2",


### PR DESCRIPTION
To cover fix for errors creating hung/stuck tests. [The issue I was having](https://github.com/facebook/create-react-app/issues/6899) seemed to have been fixed when upgrading one of my personal projects. Didn't have any negative effects on others.